### PR TITLE
Misc fixes

### DIFF
--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -13,8 +13,6 @@ from logging import getLogger
 from feedgen.feed import FeedGenerator
 from feedgen.feed import FeedEntry
 
-import rstgen
-
 doc_trees = []  # for atelier
 logger = getLogger(__name__)
 
@@ -48,7 +46,7 @@ def setup(app):
     app.add_config_value('feed_field_name', 'Publish Date', 'env')
     app.add_config_value('feed_filename', 'rss.xml', 'html')
     app.add_config_value('feed_use_atom', False, 'html')
-    # app.add_config_value('use_dirhtml', False, 'html')
+    app.add_config_value('use_dirhtml', False, 'html')
 
     app.connect('html-page-context', create_feed_item)
     app.connect('build-finished', emit_feed)
@@ -103,7 +101,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     item = FeedEntry()
     item.title(ctx.get('title'))
     href = app.config.feed_base_url + '/' + ctx['current_page_name']
-    if not rstgen.get_config_var('use_dirhtml'):
+    if not app.config.use_dirhtml:
         href += ctx['file_suffix']
     item.link(href=href)
     if app.config.feed_use_atom:

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -66,7 +66,7 @@ def create_feed_container(app):
     feed.link(href=app.config.feed_base_url)
     if USE_ATOM:
         feed.id(app.config.feed_base_url)
-    feed.author(dict(name=app.config.feed_author))
+    feed.author({'name': app.config.feed_author})
     feed.description(app.config.feed_description)
 
     if app.config.language:
@@ -112,13 +112,18 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     item.description(ctx.get('body'))
     item.published(pubDate)
 
-    if 'author' in metadata:
-        item.author(metadata['author'])
-
+    if author := metadata.get('author'):
+        # author may be a str (in field list/frontmatter) or a dict (expected by feedgen)
+        if isinstance (author, str):
+            author = {'name': author}
+        item.author(author)
     if cat := metadata.get("category", None):
         item.category(term=cat)
     if tags := metadata.get("tags", None):
-        for tag in tags.split():
+        # tags may be a str (in field list/frontmatter), or a list (from sphinx-tags extension)
+        if isinstance(tags, str):
+            tags = tags.split()
+        for tag in tags:
             item.category(term=tag)
 
     env.feed_items[pagename] = item

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -8,6 +8,7 @@ import os.path
 import time
 from datetime import datetime
 from dateutil.tz import tzlocal
+from logging import getLogger
 
 from feedgen.feed import FeedGenerator
 from feedgen.feed import FeedEntry
@@ -17,6 +18,7 @@ import rstgen
 USE_ATOM = True
 
 doc_trees = []  # for atelier
+logger = getLogger(__name__)
 
 
 def parse_pubdate(pubdate):
@@ -90,7 +92,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     pubDate = parse_pubdate(pubDate)
 
     if pubDate > time.localtime():
-        # raise Exception("20200131 {} > {}".format(pubDate, time.gmtime()))
+        logger.warning("Skipping %s, publish date is in the future: %s", pagename, pubDate)
         return
 
     if not ctx.get('body') or not ctx.get('title'):

--- a/sphinxfeed.py
+++ b/sphinxfeed.py
@@ -15,8 +15,6 @@ from feedgen.feed import FeedEntry
 
 import rstgen
 
-USE_ATOM = True
-
 doc_trees = []  # for atelier
 logger = getLogger(__name__)
 
@@ -49,6 +47,7 @@ def setup(app):
     app.add_config_value('feed_author', '', 'html')
     app.add_config_value('feed_field_name', 'Publish Date', 'env')
     app.add_config_value('feed_filename', 'rss.xml', 'html')
+    app.add_config_value('feed_use_atom', False, 'html')
     # app.add_config_value('use_dirhtml', False, 'html')
 
     app.connect('html-page-context', create_feed_item)
@@ -64,7 +63,7 @@ def create_feed_container(app):
     feed = FeedGenerator()
     feed.title(app.config.project)
     feed.link(href=app.config.feed_base_url)
-    if USE_ATOM:
+    if app.config.feed_use_atom:
         feed.id(app.config.feed_base_url)
     feed.author({'name': app.config.feed_author})
     feed.description(app.config.feed_description)
@@ -107,7 +106,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
     if not rstgen.get_config_var('use_dirhtml'):
         href += ctx['file_suffix']
     item.link(href=href)
-    if USE_ATOM:
+    if app.config.feed_use_atom:
         item.id(href)
     item.description(ctx.get('body'))
     item.published(pubDate)
@@ -143,8 +142,9 @@ def emit_feed(app, exc):
         #     getattr(e, k)(v)
 
     path = os.path.join(app.builder.outdir, app.config.feed_filename)
+
     # print(20190315, path)
-    if USE_ATOM:
+    if app.config.feed_use_atom:
         feed.atom_file(path)
     else:
         feed.rss_file(path)


### PR DESCRIPTION
Fixes the following minor issues I found while testing this out:

* Generating an atom feed is hardcoded; use a sphinx config option instead
* Depends on a package `rstgen` not declared in dependencies. It looks like it's just being used to fetch one config value from `conf.py`, so updated this to get it via sphinx config instead.
* When specifying `author` in the fields list (rst) or frontmatter (markdown), it gets passed to feedgen as a string instead of as a dict:
    ```py
    Traceback (most recent call last):
    File "sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "sphinxfeed.py", line 102, in create_feed_item
    item.author(author)
    File "feedgen/entry.py", line 363, in author
    self.__atom_author += ensure_format(author,
                          ^^^^^^^^^^^^^^^^^^^^^
    File "feedgen/util.py", line 61, in ensure_format
    raise ValueError('Invalid data (value is no dictionary)')
    ```
* When using the sphinx-tags extension, its `tags` directive gets picked up as page metadata, as a list instead of a string:
    ```py
    Traceback (most recent call last):
      File "sphinx/events.py", line 97, in emit
        results.append(listener.handler(self.app, *args))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "sphinxfeed.py", line 107, in create_feed_item
        tags = tags.split()
               ^^^^^^^^^^
    AttributeError: 'list' object has no attribute 'split'
    ```